### PR TITLE
fix: CI workflow bugs blocking Tutorial 01 PR

### DIFF
--- a/.github/workflows/backlog-health-check.yml
+++ b/.github/workflows/backlog-health-check.yml
@@ -180,7 +180,7 @@ jobs:
               body += `**${r.title}**\n\n`;
 
               if (missingHooks.length > 0) {
-                body += `\u274C **Missing hooks/exports:** ${missingHooks.map(h => \`\\\`${h.name}\\\`\`).join(', ')}\n`;
+                body += '\u274C **Missing hooks/exports:** ' + missingHooks.map(h => '`' + h.name + '`').join(', ') + '\n';
               }
               if (brokenDocs.length > 0) {
                 body += `\u274C **Broken docs pages:**\n`;

--- a/.github/workflows/validate-tutorial-pr.yml
+++ b/.github/workflows/validate-tutorial-pr.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Validate tutorial PR
         uses: actions/github-script@v7


### PR DESCRIPTION
## Summary
Fixes two CI workflows that were failing on May's Tutorial 01 PR (#9).

### validate-tutorial-pr.yml
`git diff --name-only origin/main...HEAD` failed with "ambiguous argument" because shallow checkout didn't fetch origin/main.
Fix: `fetch-depth: 0`

### backlog-health-check.yml  
`SyntaxError: Invalid or unexpected token` from nested template literal backtick escaping inside YAML script block.
Fix: replaced with string concatenation.

## Test plan
- [ ] After merge, re-run Tutorial Completeness Check on PR #9
- [ ] Trigger Backlog Health Check manually via workflow_dispatch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to improve validation reliability and report generation accuracy during development and tutorial pull request processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->