### PR TITLE
chore: update Tutorial 02 template for v14.3.1

### DIFF
--- a/.github/tutorial-templates/02-expo-clerk.json
+++ b/.github/tutorial-templates/02-expo-clerk.json
@@ -9,8 +9,8 @@
   "unlock_phrase": "biometric-sailor",
   "next_template": "03-python-wallet.json",
   "packages": {
-    "@chipi-stack/chipi-expo": "^14.1.1",
-    "@chipi-stack/chipi-passkey": "^2.0.1"
+    "@chipi-stack/chipi-expo": "^14.3.1",
+    "@chipi-stack/chipi-passkey": "^2.1.0"
   },
   "hooks_to_exercise": [
     "useCreateWallet",
@@ -19,6 +19,7 @@
     "useGetTokenBalance",
     "useTransfer",
     "useGetTransactionList",
+    "useSyncOnChainTransfers",
     "useMigrateWalletToPasskey",
     "createNativeWalletPasskey",
     "isNativeBiometricSupported"


### PR DESCRIPTION
## Summary

Updates the Tutorial 02 (Expo + Clerk) generation template to use the just-released `@chipi-stack/chipi-expo@14.3.1` and adds `useSyncOnChainTransfers` to the hooks list.

### Changes to `.github/tutorial-templates/02-expo-clerk.json`

| Field | Before | After | Why |
|---|---|---|---|
| `@chipi-stack/chipi-expo` | `^14.1.1` | `^14.3.1` | v14.3.1 adds `useSyncOnChainTransfers` export + dual-key passkey flow |
| `@chipi-stack/chipi-passkey` | `^2.0.1` | `^2.1.0` | Dual-key + PRF fix shipped in v14.3.0 |
| `hooks_to_exercise` | 9 hooks | 10 hooks (+`useSyncOnChainTransfers`) | Root cause of May's "empty transaction list" in sdks#191 — the hook was missing from chipi-expo |

### What happens after merge

The `generate-tutorial.yml` workflow fetches the **latest docs from `chipi-pay/sdks` main** at generation time (line 76-78 of the workflow). Since the sdks docs are now updated with all v14.3.1 fixes (secret key removal, dual-key flow, SDK 55 upgrade step, `result.wallet` fix, `chain: Chain.STARKNET`), the generated Tutorial 02 project will automatically incorporate the corrected examples.

After this merges, trigger the workflow:
```
gh workflow run generate-tutorial.yml --repo chipi-pay/build-with-chipi -f template_file=02-expo-clerk.json -f issue_number=11
```

This will generate the tutorial project on a `tutorial/02-expo-clerk` branch and comment on issue #11 with instructions for @YrandaNova.

Refs chipi-pay/sdks#191

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated library dependencies to latest versions (`@chipi-stack/chipi-expo` and `@chipi-stack/chipi-passkey`).

* **Documentation**
  * Extended tutorial exercises with a new hook for on-chain transfer synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->