### PR TITLE
chore(sdk): v14.9.0 changelog + tutorial dep bumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to the `@chipi-stack` SDK packages are documented here.
 
+## v14.9.0 (2026-06-16)
+
+### `@chipi-stack/chipi-react`
+
+- **Embeddable multisig governance UI** on the `@chipi-stack/chipi-react/multisig` subpath: `<ProposeAction>` (template-driven propose dialog with a live "what this does" preview), `<Approvals>` (pending/recent list with Approve/Execute and a `renderContext` slot), and `<ApprovalInbox>` (cross-treasury "what needs me", mobile-first). Themeable via CSS-var tokens, zero Tailwind/CSS-import requirement, tree-shakeable. Built on the existing `useProposeAction` / `useTreasuryProposals` hooks — transports/signers inject as before.
+- **Risk tiers** — `ActionTemplate.risk?: "ROUTINE" | "SENSITIVE"` flows through `createProposal`; `TreasuryProposal.risk` is returned in lists and `<Approvals>` shows a "Sensitive" chip (the backend applies the treasury's per-tier quorum policy).
+- **Agent-proposer affordance** — `<Approvals>` / `<ApprovalInbox>` accept `isAgentProposal` + `agentLabel`, rendering an escalated agent proposal as "{label} wants: {title}" with an Agent chip.
+- **Fix (H3):** `buildExecuteCalldata` now wraps exactly `requiredApprovals` signatures (lowest owner indices) instead of every collected one — prevents an extra/stale signature reverting the V2_THRESHOLD execute.
+
+### `@chipi-stack/backend`
+
+- **`ShhhAccount`** — an ergonomic drop-in adapter for signing as a SHHH V8.4 owner from a raw (exported) STARK private key. SHHH accounts have `__validate__` disabled, so the standard `new Account(...).execute()` path doesn't work; `ShhhAccount` hides the `execute_from_outside_v2` plumbing so a key holder can write `const { transactionHash } = await account.execute(calls)`. Pairs with the wallet's "export private key" self-custody flow.
+- **Owner-pubkey formatters** — `eip191OwnerPubkeyParam`, `ed25519OwnerPubkeyParam`, `webauthnOwnerPubkeyParam` produce the kind-specific `ownerPubkey` string the treasury coordination endpoints expect (`sdk.treasury.forTreasury({ ownerPubkey })`). The coordinate kinds (WebAuthn/EIP-191) take the full `"x,y"` BE coordinates; Ed25519 takes `"low,high"` LE u128 halves — not the 4-felt `*PubkeyFelts` form.
+
+- Additive; no existing exports changed. The rest of the fixed version group (`types`, `shared`, `nextjs`, `chipi-expo`, `x402`) bumps to 14.9.0 version-only. `core` (0.3.1) and `chipi-passkey` (2.2.0) are unchanged.
+
+_Sources_: [`sdks#328`](https://github.com/chipi-pay/sdks/pull/328), [`sdks#329`](https://github.com/chipi-pay/sdks/pull/329), [`sdks#330`](https://github.com/chipi-pay/sdks/pull/330), [`sdks#331`](https://github.com/chipi-pay/sdks/pull/331), [`sdks#332`](https://github.com/chipi-pay/sdks/pull/332), [`sdks#350`](https://github.com/chipi-pay/sdks/pull/350), [`sdks#351`](https://github.com/chipi-pay/sdks/pull/351).
+
 ## v14.8.0 (2026-06-05)
 
 ### `@chipi-stack/chipi-react`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,18 @@ All notable changes to the `@chipi-stack` SDK packages are documented here.
 - **`ShhhAccount`** — an ergonomic drop-in adapter for signing as a SHHH V8.4 owner from a raw (exported) STARK private key. SHHH accounts have `__validate__` disabled, so the standard `new Account(...).execute()` path doesn't work; `ShhhAccount` hides the `execute_from_outside_v2` plumbing so a key holder can write `const { transactionHash } = await account.execute(calls)`. Pairs with the wallet's "export private key" self-custody flow.
 - **Owner-pubkey formatters** — `eip191OwnerPubkeyParam`, `ed25519OwnerPubkeyParam`, `webauthnOwnerPubkeyParam` produce the kind-specific `ownerPubkey` string the treasury coordination endpoints expect (`sdk.treasury.forTreasury({ ownerPubkey })`). The coordinate kinds (WebAuthn/EIP-191) take the full `"x,y"` BE coordinates; Ed25519 takes `"low,high"` LE u128 halves — not the 4-felt `*PubkeyFelts` form.
 
+- **Fix (C1) — gasless SHHH transfer reliability:** `executeTransaction` / `transfer` / `callAnyContract` now resolve `walletType` from the on-chain class hash when the caller omits it. A SHHH wallet passed without `walletType` previously defaulted to `READY` and was estimated as a direct sender, which panicked `C1: invalid tx version` and failed the transfer; it now resolves to SHHH and routes through the OutsideExecution path. CHIPI/READY behavior is unchanged. One extra RPC read, only when `walletType` is omitted.
+
 - Additive; no existing exports changed. The rest of the fixed version group (`types`, `shared`, `nextjs`, `chipi-expo`, `x402`) bumps to 14.9.0 version-only. `core` (0.3.1) and `chipi-passkey` (2.2.0) are unchanged.
 
-_Sources_: [`sdks#328`](https://github.com/chipi-pay/sdks/pull/328), [`sdks#329`](https://github.com/chipi-pay/sdks/pull/329), [`sdks#330`](https://github.com/chipi-pay/sdks/pull/330), [`sdks#331`](https://github.com/chipi-pay/sdks/pull/331), [`sdks#332`](https://github.com/chipi-pay/sdks/pull/332), [`sdks#350`](https://github.com/chipi-pay/sdks/pull/350), [`sdks#351`](https://github.com/chipi-pay/sdks/pull/351).
+<!-- Intentionally NOT documented in 14.9.0: the get-starknet dApp connector
+     (createChipiWindowObject / ChipiInjector / useChipiWalletObject, sdks#352)
+     publishes in this version but is a Phase-0 primitive with no end-to-end
+     walletv2 integration yet. Held back from the public changelog until the
+     consumer-facing "Connect with Chipi" surface ships, to avoid pointing
+     integrators at a half-built path. Flip this when walletv2 integrates it. -->
+
+_Sources_: [`sdks#328`](https://github.com/chipi-pay/sdks/pull/328), [`sdks#329`](https://github.com/chipi-pay/sdks/pull/329), [`sdks#330`](https://github.com/chipi-pay/sdks/pull/330), [`sdks#331`](https://github.com/chipi-pay/sdks/pull/331), [`sdks#332`](https://github.com/chipi-pay/sdks/pull/332), [`sdks#350`](https://github.com/chipi-pay/sdks/pull/350), [`sdks#351`](https://github.com/chipi-pay/sdks/pull/351), [`sdks#356`](https://github.com/chipi-pay/sdks/pull/356).
 
 ## v14.8.0 (2026-06-05)
 

--- a/tutorials/01-nextjs-clerk-wallet/package.json
+++ b/tutorials/01-nextjs-clerk-wallet/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@chipi-stack/chipi-passkey": "^2.0.1",
-    "@chipi-stack/nextjs": "14.2.1",
+    "@chipi-stack/nextjs": "14.9.0",
     "@clerk/nextjs": "^7.0.7",
     "next": "16.2.1",
     "react": "19.2.4",

--- a/tutorials/02-expo-clerk-mobile-wallet/package.json
+++ b/tutorials/02-expo-clerk-mobile-wallet/package.json
@@ -11,7 +11,7 @@
     "lint": "expo lint"
   },
   "dependencies": {
-    "@chipi-stack/chipi-expo": "14.3.1",
+    "@chipi-stack/chipi-expo": "14.9.0",
     "@clerk/clerk-expo": "^2.19.31",
     "@expo-google-fonts/jetbrains-mono": "^0.4.1",
     "@expo-google-fonts/playfair-display": "^0.4.2",


### PR DESCRIPTION
14.9.0 is now published to npm. Merges the prepared changelog (governance UI, risk tiers, agent-proposer, H3 fix, ShhhAccount, owner-pubkey formatters, C1 walletType fix) + tutorial pins 14.2.1/14.3.1 → 14.9.0. dApp connector intentionally undocumented (HTML-comment flag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## v14.9.0 Release

* **New Features**
  * Introduced embeddable governance UI components for multisig operations, including risk assessment and proposal management features.

* **Bug Fixes**
  * Fixed signature wrapping logic in execute calldata.
  * Resolved wallet type detection for gasless transfers.
  * Added backend signing adapter capability.

* **Chores**
  * Updated tutorial package dependencies to v14.9.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->