### PR TITLE
docs(changelog): mark v14.11.0 released

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the `@chipi-stack` SDK packages are documented here.
 
-## v14.11.0 (unreleased)
+## v14.11.0 (2026-08-12)
 
 ### Packaging: CommonJS now works everywhere
 


### PR DESCRIPTION
Flips the `v14.11.0` heading from `(unreleased)` to its publish date, now that the packages are live.

Published 2026-08-12:

| Package | Version |
|---|---|
| backend, types, shared, chipi-react, nextjs, chipi-expo, x402 | 14.11.0 |
| core | 0.6.0 |
| starknet-connector | 0.3.0 |
| chipi-passkey | unchanged (2.2.0) |

Verified from the registry, not from a local build: installed `@chipi-stack/backend@14.11.0` into a clean CommonJS project and confirmed `require()` of backend, nextjs and core all load, plus the `tsx` path that previously threw `ERR_PACKAGE_PATH_NOT_EXPORTED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfgkcB1sohv2CcTfsBP7Gr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the v14.11.0 changelog entry with its release date: August 12, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->